### PR TITLE
add css resolve exception for css behavior prop

### DIFF
--- a/lasso-resolve-css-urls-plugin.js
+++ b/lasso-resolve-css-urls-plugin.js
@@ -75,6 +75,12 @@ module.exports = function (lasso, pluginConfig) {
 
                 // the replacer function
                 function(url, start, end, callback) {
+
+                    if(url.startsWith('#default')) {
+                        callback(null, url);
+                        return;
+                    }
+                    
                     urlResolver(url, lassoContext, function(err, url) {
                         if (err || !url) {
                             return callback(err);


### PR DESCRIPTION
Lasso encountered an error while [trying to resolve](https://github.com/Leaflet/Leaflet/blob/master/dist/leaflet.css#L109) 
`	behavior: url(#default#VML);`

This is some sort of css extensions for IE browsers. Apart from Script URL, and #Object ID, it allows us to specify default behaviors shipped with the browser using #default. Maybe we could add an exception to resolve url's beginning with #default?

More info on behavior property [here](https://stackoverflow.com/questions/26339276/what-is-behavior-url-property-in-css).